### PR TITLE
Added documentation files for items and blocks

### DIFF
--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/camera.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/camera.md
@@ -1,0 +1,3 @@
+# Camera
+
+The camera block adds ray casting functionality to computers. The `'distance()` function calculates the distance to the nearest block along the specified ray, which is defined by angles `x` and `y`; if no angle is specified, the angle values default to 0. Both angles form a frontal cone in front of the camera, with `x` being the angle on a horizontal plane parallel to the ground, and `y`, the angle on a vertical plane perpendicular to the ground. If no block exists in the path of the ray, a value of `-1` is returned. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/chatbox.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/chatbox.md
@@ -1,0 +1,5 @@
+# Chat Box
+
+The chat box allows the computer to write/read messages to/from the Minecraft chatbox. For reading messages, a listening distance can be specified (default: 40 blocks). This can allow programs on the computer to be triggered from the chatbox, by reading the message contained in the `chat_message` event. 
+
+The chat box emits a 4-tick redstone pulse upon receiving a message, for integration with various redstone control. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/cipher.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/cipher.md
@@ -1,0 +1,5 @@
+# Cipher Block
+
+The cipher block is used to encrypt and decrypt messages. Items can be placed inside the cipher block to generate the encryption key using the Itemstack information. Messages can then be decrypted using a cipher block with the exact same encryption key. For example, encrypted messages can be sent to other computers on a network; the receiving computer will need a cipher block with the same combination of items to decipher the received message. The cipher block can be locked via the component API, preventing access to the block's GUI (and hiding the encryption key). 
+
+The advanced cipher block uses RSA encryption, by creating a public and private key pair. The key pair can be generated using a pair of prime numbers or randomly. The public key is used to encrypt messages, while the private key is used to decrypt messages. Only devices with access to the private key may decrypt messages. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/cipher_advanced.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/cipher_advanced.md
@@ -1,0 +1,1 @@
+#REDIRECT cipher.md

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/colorful_lamp.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/colorful_lamp.md
@@ -1,0 +1,3 @@
+# Colorful Lamp
+
+The colorful lamp is a special light block allowing for up to 32768 color combinations. Colors are defined as a 15-bit binary. The last 5 digits control shades of blue; the middle 5, shades of green; and the first 5, shades of red. For instance, the binary representation `000000000011111` (converted to a decimal value) would result in a blue color. The colorful lamp can be used as a status block, where different colors could represent different states of a program running on the computer. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/eeprom_reader.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/eeprom_reader.md
@@ -1,0 +1,3 @@
+# EEPROM Reader
+
+The EEPROM reader allows computers to read and write EEPROM initialized by NedoComputers. The EEPROM is inserted onto the top face of the EEPROM reader, and can be accessed using the `eeprom_reader` component. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/iron_noteblock.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/iron_noteblock.md
@@ -1,0 +1,3 @@
+# Iron Note Block
+
+The Iron note block is capable of playing various notes using different instruments. These instruments (such as the piano or bass drum) are defined by the Minecraft note block. The note block is capable of playing 24 notes per instrument, and takes an optional volume parameter between 0 to 1. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/radar.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/radar.md
@@ -1,0 +1,5 @@
+# Radar
+
+The radar block behaves similarly to the motion sensor in Open Computers, allowing detection of entities such as players, mobs, and dropped items. The built in API functions return a table of entity names and distances within a specified range (with the option of returning distances relative to the radar block). 
+
+The radar block requires a certain amount of power for scanning larger areas (with Open Computers), or has a delay between scans (ComputerCraft).

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/railcraft/digital_detector.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/railcraft/digital_detector.md
@@ -1,0 +1,3 @@
+# Digital Detector
+
+The Digital detector block detects when a minecart passes adjacent to the block, firing a `minecart` lua event, which can be detected by a computer. The digital detector must be connected to a computer using a cable, which connects to the face with a yellow dot (on the detector). 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/railcraft/digital_receiver_box.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/railcraft/digital_receiver_box.md
@@ -1,0 +1,3 @@
+# Digital Signal Receiver
+
+The Digital signal receiver allows for detecting of aspect changes, and is connected using a cable on the top or bottom face of the signal receiver. Signal aspects are defined as per Railcraft's [signaling](http://railcraft.info/wiki/guide:signalling) documentation (aspects include green, yellow blinking, yellow, red blinking, and red). 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/railcraft/locomotive_relay.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/railcraft/locomotive_relay.md
@@ -1,0 +1,3 @@
+# Locomotive Relay
+
+The Locomotive relay allows computers to communicate with the Electric locomotive from Railcraft. A [digital relay sensor](../../item/railcraft/relay_sensor.md) is needed for pairing: sneak right-click to bind the [relay sensor](../../item/railcraft/relay_sensor.md) to the Locomotive relay, then sneak left-click on an electric locomotive to attach the [sensor](../../item/railcraft/relay_sensor.md) to the locomotive. Once attached, the electric locomotive can be controlled using the `locomotive_relay` component API. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/railcraft/ticket_machine.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/railcraft/ticket_machine.md
@@ -1,0 +1,5 @@
+# Ticket Machine
+
+The ticket machine allows players to print tickets using golden tickets as a template. Golden tickets can be configured using the `ticket_machine` component API, as well as using the interface in maintenance mode (sneak right-click on the Ticket machine block with an empty hand). Once configured, tickets can be printed using the Ticket machine GUI (by selecting the golden ticket and clicking print) or using the component API (by specifying the desired golden ticket slot). Printing tickets require a certain amount of power and regular Minecraft paper (which can be placed into the paper slot in maintenance-mode). 
+
+Optionally, manual printing of tickets (via the Ticket machine GUI) can be disabled using the component API, which only allows for printing using the component API functions. Maintenance mode can also be locked to the device owner and Ops only, if desired. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/block/tape_drive.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/block/tape_drive.md
@@ -1,0 +1,7 @@
+# Tape Drive
+
+The tape drive is a block that allows for playback and recording of audio data. [Cassette tapes](../item/tape.md) can be placed into the tape drive, and come in durations of 2 to 128 minutes. Note that the tape drive isn't restricted to purely audio data - other types of data can be written to the [cassette](../item/tape.md).
+
+Audio is recorded in the DFPWM format, due to the low filesize. Converting from MP3 or other common audio formats is tricky; however, it is possible to convert from WAV files to DFPWM using a program called [LionRay](http:/dl.dropboxusercontent.com/u/93572794/LionRay.jar). The converted audio file can then be written, byte-by-byte, to the cassette tape. 
+
+The tape drive also has a `seek()` function, allowing fast-forwarding to a specific point on the [cassette tape](../item/tape.md). Providing a negative value to the `seek()` rewinds the [cassette tape](../item/tape.md) to an earlier point. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/item/beep_card.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/item/beep_card.md
@@ -1,0 +1,3 @@
+# Beep Card
+
+The Beep card provides the `beep()` function, which takes a table of frequency-duration pairs as an input. The beep card plays each frequency of beeps for the specified duration. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/item/buildcraft/docking_upgrade.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/item/buildcraft/docking_upgrade.md
@@ -1,0 +1,3 @@
+# Drone Docking Upgrade 
+
+The Drone docking upgrade is an upgrade which allows drones to dock onto a Buildcraft pipe with a [docking station](drone_station.md). Docking upgrades can be placed into a drone with a tier 1 upgrade slot or higher. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/item/buildcraft/drone_station.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/item/buildcraft/drone_station.md
@@ -1,0 +1,3 @@
+# Drone Docking Station
+
+The Drone docking station is an item that connects to any Buildcraft pipe, allowing drones with the [docking upgrade](docking_upgrade.md) to dock. This allows for items to be transferred to and from Buildcraft pipe networks. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/item/camera_upgrade.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/item/camera_upgrade.md
@@ -1,0 +1,3 @@
+# Camera Upgrade
+
+The Camera upgrade can be placed in robots and drones with a tier 2 upgrade slot or higher, and provide identical functionality as the [camera](../block/camera.md) block. However, the camera upgrade has the added functionality of having two extra functions, namely `distanceUp()` and `distanceDown()` which behave as a camera pointed directly up or down, respectively. This allows robots and drones to create height maps, for instance. Both functions take the same `x` and `y` parameters, and define an upward or downward facing cone similarly to the frontal cone created by the camera block. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/item/chat_upgrade.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/item/chat_upgrade.md
@@ -1,0 +1,5 @@
+# Chat Upgrade
+
+The chat upgrade can be placed into robots and drones with a tier 2 upgrade slot or higher. The upgrade behaves similarly to the [chat box](../block/chat_box.md) allowing for integration with the Minecraft chat box. As with the [chat box](../block/chat_box.md), listening distance can be specified up to a maximum (which can be defined in the configs). 
+
+Possible uses could include triggering certain programs on the robot and drone by typing commands in the chat box, with the robot and drone set to look for specific chat box messages. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/item/particle_card.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/item/particle_card.md
@@ -1,0 +1,3 @@
+# Particle Effects Card
+
+The Particle effects card allows computers, robots, and drones (containing a tier 2 upgrade slot or higher) to create particle effects at a specified location, as defined by the coordinates relative to the device. The particle name provided to the component API function must be a valid Minecraft particle. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/item/radar_upgrade.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/item/radar_upgrade.md
@@ -1,0 +1,3 @@
+# Radar Upgrade
+
+The Radar upgrade provides the same functionality as the [radar](../block/radar.md) block, and can be placed into a robot or drone with a tier 3 upgrade slot. This allows robots and drones to detect nearby entities, such as players, mobs, or dropped items. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/item/railcraft/relay_sensor.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/item/railcraft/relay_sensor.md
@@ -1,0 +1,3 @@
+# Digital Relay Sensor
+
+The Digital relay sensor is used to pair a [locomotive relay](../../block/railcraft/locomotive_relay.md) with an electric locomotive from Railcraft. Devices are paired by first sneak right-clicking the relay sensor on the [locomotive relay](../../block/railcraft/locomotive_relay.md), followed by sneak left-clicking the electric locomotive to attach the relay sensor. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/item/self_destructing_card.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/item/self_destructing_card.md
@@ -1,0 +1,3 @@
+# Self-Destructing Card
+
+The Self-destructing card allows for computers or robots to self-destruct after a specified duration (default 5 seconds). Devices are completely and irreversibly destroyed. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/item/spoofing_card.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/item/spoofing_card.md
@@ -1,0 +1,3 @@
+# Spoofing Card
+
+The spoofing card acts the same way as a network card from Open Computers, but allows players to specify the source address, effectively masking the device sending the network messages. The spoofing card requires a tier 2 card slot or higher. 

--- a/src/main/resources/assets/computronics/doc/computronics/en_US/item/tape.md
+++ b/src/main/resources/assets/computronics/doc/computronics/en_US/item/tape.md
@@ -1,0 +1,3 @@
+# Cassette Tape
+
+Cassette tapes are used for recording and playback of audio using the [tape drive](../block/tape_drive.md). Tapes come in varying lengths from 2 to 128 minutes, and can also be used to store other types of information (in which case, storage space ranging from 1 to 8 MB). Audio is recorded using the DFPWM format, as detailed in the [tape drive](../block/tape_drive.md) document. 


### PR DESCRIPTION
Added concise documentation, to the best of my knowledge and understanding. 
The beep card could use a simplified example of how to use it (read: I suck at lua tables and couldn't figure it out :D)

Links should all work (checked most of them, particularly the railcraft/buildcraft item/block linking). 

I am also a goof and completely forgot the main index with a summary. I guess it could be omitted. 