### PR TITLE
Moved not-enough-data timeout to the server

### DIFF
--- a/src/main/java/pl/asie/computronics/Computronics.java
+++ b/src/main/java/pl/asie/computronics/Computronics.java
@@ -24,6 +24,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.MinecraftForge;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import pl.asie.computronics.api.audio.AudioPacketRegistry;
 import pl.asie.computronics.api.multiperipheral.IMultiPeripheralProvider;
 import pl.asie.computronics.api.multiperipheral.IMultiPeripheralRegistry;
 import pl.asie.computronics.audio.DFPWMPlaybackManager;
@@ -111,8 +112,9 @@ public class Computronics {
 	public static TapeStorageEventHandler storageEventHandler;
 	public static ManagedGuiHandler gui;
 	public static PacketHandler packet;
-	public DFPWMPlaybackManager audio;
 	public static ExecutorService rsaThreads;
+	public DFPWMPlaybackManager audio;
+	public int managerId;
 
 	@SidedProxy(clientSide = "pl.asie.computronics.ClientProxy", serverSide = "pl.asie.computronics.CommonProxy")
 	public static CommonProxy proxy;
@@ -181,6 +183,9 @@ public class Computronics {
 		config = new Config(event);
 
 		audio = new DFPWMPlaybackManager(proxy.isClient());
+
+		managerId = AudioPacketRegistry.INSTANCE.registerManager(audio);
+
 		packet = new PacketHandler(Mods.Computronics, new NetworkHandlerClient(), new NetworkHandlerServer());
 
 		compat = new Compat(this.config.config);

--- a/src/main/java/pl/asie/computronics/api/audio/AudioPacketRegistry.java
+++ b/src/main/java/pl/asie/computronics/api/audio/AudioPacketRegistry.java
@@ -4,20 +4,23 @@ import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.TObjectIntMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.map.hash.TObjectIntHashMap;
+import pl.asie.lib.audio.StreamingPlaybackManager;
 
 public final class AudioPacketRegistry {
 	public static final AudioPacketRegistry INSTANCE = new AudioPacketRegistry();
 
 	private final TObjectIntMap<Class<? extends AudioPacket>> audioPacketIdMap = new TObjectIntHashMap<Class<? extends AudioPacket>>();
 	private final TIntObjectMap<AudioPacketClientHandler> audioPacketHandlerMap = new TIntObjectHashMap<AudioPacketClientHandler>();
-	private int nextId;
+	private final TIntObjectMap<StreamingPlaybackManager> playbackManagerMap = new TIntObjectHashMap<StreamingPlaybackManager>();
+	private int nextTypeId;
+	private int nextManagerId;
 
 	private AudioPacketRegistry() {
 
 	}
 
 	public void registerType(Class<? extends AudioPacket> type) {
-		audioPacketIdMap.put(type, nextId++);
+		audioPacketIdMap.put(type, nextTypeId++);
 	}
 
 	public int getId(Class<? extends AudioPacket> packetClass) {
@@ -30,5 +33,15 @@ public final class AudioPacketRegistry {
 
 	public AudioPacketClientHandler getClientHandler(int id) {
 		return audioPacketHandlerMap.get(id);
+	}
+
+	public int registerManager(StreamingPlaybackManager manager) {
+		int managerId = nextManagerId++;
+		playbackManagerMap.put(managerId, manager);
+		return managerId;
+	}
+
+	public StreamingPlaybackManager getManager(int id) {
+		return playbackManagerMap.get(id);
 	}
 }

--- a/src/main/java/pl/asie/computronics/audio/AudioUtils.java
+++ b/src/main/java/pl/asie/computronics/audio/AudioUtils.java
@@ -1,6 +1,7 @@
 package pl.asie.computronics.audio;
 
 import pl.asie.computronics.Computronics;
+import pl.asie.computronics.api.audio.AudioPacketRegistry;
 import pl.asie.computronics.network.PacketType;
 import pl.asie.lib.network.Packet;
 
@@ -10,11 +11,12 @@ public final class AudioUtils {
 
 	}
 
-	public static void removePlayer(int id) {
-		Computronics.instance.audio.removePlayer(id);
+	public static void removePlayer(int managerId, int codecId) {
+		AudioPacketRegistry.INSTANCE.getManager(managerId).removePlayer(codecId);
 		try {
 			Packet pkt = Computronics.packet.create(PacketType.AUDIO_STOP.ordinal())
-				.writeInt(id);
+				.writeInt(managerId)
+				.writeInt(codecId);
 			Computronics.packet.sendToAll(pkt);
 		} catch(Exception e) {
 			e.printStackTrace();

--- a/src/main/java/pl/asie/computronics/audio/SoundCardPacketClientHandler.java
+++ b/src/main/java/pl/asie/computronics/audio/SoundCardPacketClientHandler.java
@@ -37,17 +37,13 @@ import java.util.Queue;
 public class SoundCardPacketClientHandler extends AudioPacketClientHandler {
 
 	private Map<String, AudioProcess> processMap = new HashMap<String, AudioProcess>();
-	private Map<String, Long> timeoutMap = new HashMap<String, Long>();
 	private int sampleRate = Config.SOUND_SAMPLE_RATE;
-	private int soundTimeoutMS = 250;
 
-	public void setProcess(String address, AudioProcess process, long timeout) {
+	public void setProcess(String address, AudioProcess process) {
 		if(process != null) {
 			processMap.put(address, process);
-			timeoutMap.put(address, timeout);
 		} else {
 			processMap.remove(address);
-			timeoutMap.remove(address);
 		}
 	}
 
@@ -97,10 +93,9 @@ public class SoundCardPacketClientHandler extends AudioPacketClientHandler {
 		}
 
 		if(!processMap.containsKey(address)) {
-			setProcess(address, new AudioUtil.AudioProcess(8), System.currentTimeMillis());
+			setProcess(address, new AudioUtil.AudioProcess(8));
 		}
 		AudioProcess process = processMap.get(address);
-		long timeout = timeoutMap.get(address);
 
 		ByteArrayOutputStream data = new ByteArrayOutputStream();
 		while(!buffer.isEmpty() || process.delay > 0) {
@@ -123,15 +118,9 @@ public class SoundCardPacketClientHandler extends AudioPacketClientHandler {
 
 		if(data.size() > 0) {
 			StreamingAudioPlayer codec = Computronics.opencomputers.audio.getPlayer(codecId);
-			if(System.currentTimeMillis() > timeout + soundTimeoutMS) {
-				codec.stop();
-				timeout = System.currentTimeMillis();
-			}
 			codec.setSampleRate(sampleRate);
 			codec.push(data.toByteArray());
 		}
-
-		timeoutMap.put(address, timeout + delay);
 	}
 
 	@Override

--- a/src/main/java/pl/asie/computronics/network/NetworkHandlerClient.java
+++ b/src/main/java/pl/asie/computronics/network/NetworkHandlerClient.java
@@ -61,8 +61,9 @@ public class NetworkHandlerClient extends MessageHandlerBase {
 			}
 			break;
 			case AUDIO_STOP: {
+				int managerId = packet.readInt();
 				int codecId = packet.readInt();
-				Computronics.instance.audio.removePlayer(codecId);
+				AudioPacketRegistry.INSTANCE.getManager(managerId).removePlayer(codecId);
 			}
 			break;
 			case PARTICLE_SPAWN: {

--- a/src/main/java/pl/asie/computronics/oc/IntegrationOpenComputers.java
+++ b/src/main/java/pl/asie/computronics/oc/IntegrationOpenComputers.java
@@ -97,6 +97,7 @@ public class IntegrationOpenComputers {
 	public static ColorfulUpgradeHandler colorfulUpgradeHandler;
 	public static DriverBoardBoom.BoomHandler boomBoardHandler;
 	public SoundCardPlaybackManager audio;
+	public int managerId;
 
 	public IntegrationOpenComputers(Computronics computronics) {
 		this.computronics = computronics;
@@ -142,6 +143,8 @@ public class IntegrationOpenComputers {
 
 		if(Config.OC_CARD_SOUND) {
 			audio = new SoundCardPlaybackManager(Computronics.proxy.isClient());
+
+			managerId = AudioPacketRegistry.INSTANCE.registerManager(audio);
 
 			AudioPacketRegistry.INSTANCE.registerType(SoundCardPacket.class);
 

--- a/src/main/java/pl/asie/computronics/tile/TapeDriveState.java
+++ b/src/main/java/pl/asie/computronics/tile/TapeDriveState.java
@@ -19,18 +19,18 @@ public class TapeDriveState {
 
 		public static final State[] VALUES = values();
 	}
-	
+
 	private State state = State.STOPPED;
 	private int codecId;//, packetId;
     private long lastCodecTime;
 	protected int packetSize = 1024;
 	protected int soundVolume = 127;
 	private ITapeStorage storage;
-	
+
 	public ITapeStorage getStorage() { return storage; }
 	protected void setStorage(ITapeStorage storage) { this.storage = storage; }
 	protected void setState(State state) { this.state = state; }
-	
+
 	public boolean setSpeed(float speed) {
 		if(speed < 0.25F || speed > 2.0F) return false;
 		this.packetSize = Math.round(1024*speed);
@@ -44,13 +44,13 @@ public class TapeDriveState {
 	public byte getVolume() {
 		return (byte) soundVolume;
 	}
-	
+
 	public void setVolume(float volume) {
 		if(volume < 0.0F) volume = 0.0F;
 		if(volume > 1.0F) volume = 1.0F;
 		this.soundVolume = (int) Math.floor(volume * 127.0F);
 	}
-	
+
 	public void switchState(World worldObj, int x, int y, int z, State newState) {
 		if(worldObj.isRemote) { // Client-side happening
 			if(newState == state) return;
@@ -58,7 +58,7 @@ public class TapeDriveState {
 		if(!worldObj.isRemote) { // Server-side happening
 			if(this.storage == null) newState = State.STOPPED;
 			if(state == State.PLAYING) { // State is playing - stop playback
-				AudioUtils.removePlayer(codecId);
+				AudioUtils.removePlayer(Computronics.instance.managerId, codecId);
 			}
 			if(newState == State.PLAYING) { // Time to play again!
 				codecId = Computronics.instance.audio.newPlayer();
@@ -69,7 +69,7 @@ public class TapeDriveState {
 		state = newState;
 		//sendState();
 	}
-	
+
 	public State getState() {
 		return state;
 	}
@@ -86,7 +86,7 @@ public class TapeDriveState {
 			return null;
 		}
 	}
-	
+
 	public AudioPacket update(IAudioSource source, World worldObj, int x, int y, int z) {
 		if(!worldObj.isRemote) {
 			switch(state) {
@@ -107,7 +107,7 @@ public class TapeDriveState {
 				case FORWARDING: {
 					int seeked = storage.seek(2048);
 					if(seeked < 2048) switchState(worldObj, x, y, z, State.STOPPED);
-				} break;	
+				} break;
 				case STOPPED: {
 				} break;
 			}


### PR DESCRIPTION
The Sound Card will now manage how long it's gone without audio data and automatically terminate it's player.
Added a manager to manage StreamingPlaybackManagers inside AudioPacketRegistry, so AUDIO_STOP can be reused for both Tape Drives and Sound Cards.

Clean up the indentation inside of TapeDriveState :/