### PR TITLE
Fixed white noise

### DIFF
--- a/src/main/java/pl/asie/computronics/oc/driver/DriverCardSound.java
+++ b/src/main/java/pl/asie/computronics/oc/driver/DriverCardSound.java
@@ -342,7 +342,7 @@ public class DriverCardSound extends ManagedEnvironment implements IAudioSource 
 		int channel = checkChannel(args);
 		int mode = args.checkInteger(1) - 1;
 		switch(mode) {
-			case -1:
+			case -2:
 				return tryAdd(new Instruction.SetWhiteNoise(channel));
 			default:
 				if(mode >= 0 && mode < AudioType.VALUES.length) {

--- a/src/main/java/pl/asie/computronics/util/sound/AudioUtil.java
+++ b/src/main/java/pl/asie/computronics/util/sound/AudioUtil.java
@@ -213,7 +213,7 @@ public class AudioUtil {
 
 	public static abstract class Noise extends Generator {
 
-		public double noiseOutput = Math.random();
+		public double noiseOutput;
 
 		public void updateModifier(State state) {
 			this.noiseOutput = generate(state);
@@ -243,7 +243,7 @@ public class AudioUtil {
 
 		@Override
 		protected double generate(State state) {
-			return Math.random();
+			return Math.random()*2-1;
 		}
 
 		@Override


### PR DESCRIPTION
The subtract by one on setWave's mode makes the case check a -2, not -1.
noiseOutput should not start at Math.random(), not all noise implementations such as the LFSR output like that which makes that a broken starting behaviour.
White noise was only operating at half of it's volume: (0 to 1) instead of (-1 to 1)