### PR TITLE
Fix skipping of attack phase

### DIFF
--- a/src/main/java/pl/asie/computronics/util/sound/AudioUtil.java
+++ b/src/main/java/pl/asie/computronics/util/sound/AudioUtil.java
@@ -179,6 +179,9 @@ public class AudioUtil {
 
 		public void reset() {
 			phase = this.initialPhase;
+			if(initialPhase == Phase.Decay) {
+				progress = 1;
+			}
 		}
 
 		private enum Phase {


### PR DESCRIPTION
If the attack phase has a time of 0ms (instant), progress must be set to 1 to simulate the instant attack too.