### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 
 Computronics is an addon for ComputerCraft and OpenComputers, also adding integration to a lot of other mods.
-###Downloads
+### Downloads
 The mod's downloads can be found at http://wiki.vex.tty.sh/wiki:computronics.
-###License
+### License
 The mod's license can be found [here](http://wiki.vex.tty.sh/wiki:licensing).
 
 This is the repository for the Computronics Minecraft mod. 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
